### PR TITLE
Improved release page build method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 source/_site/
+source/.jekyll-cache/

--- a/downloads.html
+++ b/downloads.html
@@ -75,7 +75,7 @@
     <tr>
         <td>Nexus</td>
         <td>1.1.0</td>
-        <td>2023-05-15</td>
+        <td>2023-05-16</td>
         <td>
             <a href="https://www.apache.org/dyn/closer.lua/incubator/sdap/1.1.0-incubating/apache-sdap-nexus-1.1.0-incubating-src.tar.gz">
                 [source] apache-sdap-nexus-1.1.0-incubating-src.tar.gz
@@ -92,7 +92,7 @@
     <tr>
         <td>Ingester</td>
         <td>1.1.0</td>
-        <td>2023-05-15</td>
+        <td>2023-05-16</td>
         <td>
             <a href="https://www.apache.org/dyn/closer.lua/incubator/sdap/1.1.0-incubating/apache-sdap-ingester-1.1.0-incubating-src.tar.gz">
                 [source] apache-sdap-ingester-1.1.0-incubating-src.tar.gz
@@ -144,7 +144,7 @@
     <tr>
         
         <td rowspan="2">1.1.0</td>
-        <td rowspan="2">2023-05-15</td>
+        <td rowspan="2">2023-05-16</td>
         
         
         <td>Nexus</td>

--- a/downloads.html
+++ b/downloads.html
@@ -59,63 +59,184 @@
 <p>The table below contains links to download the Apache SDAP (incubating) module source distributions as well as their signature and checksum files from ASF mirrors.</p>
 
 <h2>SDAP</h2>
-
+<h3>Latest Components</h3>
 <table class="version-table">
     <thead>
     <tr>
-        <th>Date</th>
-        <th>Version</th>
-        <th>Module</th>
+        <th>Component</th>
+        <th>Release Version</th>
+        <th>Release Date</th>
         <th>Source Distribution</th>
     </tr>
     </thead>
     <tbody>
-    <tr>
-        <td rowspan="3">2023-01-18</td>
-        <td rowspan="3">v1.0.0</td>
-        <td>Ingester</td>
-        <td>
-            <a href="https://www.apache.org/dyn/closer.lua/incubator/sdap/1.0.0-incubating/apache-sdap-ingester-1.0.0-incubating-src.tar.gz">
-                [source] apache-sdap-ingester-1.0.0-incubating-src.tar.gz
-            </a>
-            <a href="https://www.apache.org/dyn/closer.lua/incubator/sdap/1.0.0-incubating/apache-sdap-ingester-1.0.0-incubating-src.tar.gz.asc">
-                [signature] apache-sdap-ingester-1.0.0-incubating-src.tar.gz
-            </a>
-            <a href="https://www.apache.org/dyn/closer.lua/incubator/sdap/1.0.0-incubating/apache-sdap-ingester-1.0.0-incubating-src.tar.gz.sha512">
-                [checksum] apache-sdap-ingester-1.0.0-incubating-src.tar.gz
-            </a>
-        </td>
-    </tr>
+    
+    
     <tr>
         <td>Nexus</td>
+        <td>1.1.0</td>
+        <td>2023-05-15</td>
         <td>
-            <a href="https://www.apache.org/dyn/closer.lua/incubator/sdap/1.0.0-incubating/apache-sdap-nexus-1.0.0-incubating-src.tar.gz">
-                [source] apache-sdap-nexus-1.0.0-incubating-src.tar.gz
+            <a href="https://www.apache.org/dyn/closer.lua/incubator/sdap/1.1.0-incubating/apache-sdap-nexus-1.1.0-incubating-src.tar.gz">
+                [source] apache-sdap-nexus-1.1.0-incubating-src.tar.gz
             </a>
-            <a href="https://www.apache.org/dyn/closer.lua/incubator/sdap/1.0.0-incubating/apache-sdap-nexus-1.0.0-incubating-src.tar.gz.asc">
-                [signature] apache-sdap-nexus-1.0.0-incubating-src.tar.gz
+            <a href="https://downloads.apache.org/incubator/sdap/1.1.0-incubating/apache-sdap-nexus-1.1.0-incubating-src.tar.gz.asc">
+                [signature] apache-sdap-nexus-1.1.0-incubating-src.tar.gz
             </a>
-            <a href="https://www.apache.org/dyn/closer.lua/incubator/sdap/1.0.0-incubating/apache-sdap-nexus-1.0.0-incubating-src.tar.gz.sha512">
-                [checksum] apache-sdap-nexus-1.0.0-incubating-src.tar.gz
+            <a href="https://downloads.apache.org/incubator/sdap/1.1.0-incubating/apache-sdap-nexus-1.1.0-incubating-src.tar.gz.sha512">
+                [checksum] apache-sdap-nexus-1.1.0-incubating-src.tar.gz
             </a>
         </td>
     </tr>
+    
     <tr>
-        <td>Nexus Proto</td>
+        <td>Ingester</td>
+        <td>1.1.0</td>
+        <td>2023-05-15</td>
+        <td>
+            <a href="https://www.apache.org/dyn/closer.lua/incubator/sdap/1.1.0-incubating/apache-sdap-ingester-1.1.0-incubating-src.tar.gz">
+                [source] apache-sdap-ingester-1.1.0-incubating-src.tar.gz
+            </a>
+            <a href="https://downloads.apache.org/incubator/sdap/1.1.0-incubating/apache-sdap-ingester-1.1.0-incubating-src.tar.gz.asc">
+                [signature] apache-sdap-ingester-1.1.0-incubating-src.tar.gz
+            </a>
+            <a href="https://downloads.apache.org/incubator/sdap/1.1.0-incubating/apache-sdap-ingester-1.1.0-incubating-src.tar.gz.sha512">
+                [checksum] apache-sdap-ingester-1.1.0-incubating-src.tar.gz
+            </a>
+        </td>
+    </tr>
+    
+    <tr>
+        <td>Nexus Protobuf</td>
+        <td>1.0.0</td>
+        <td>2023-01-18</td>
         <td>
             <a href="https://www.apache.org/dyn/closer.lua/incubator/sdap/1.0.0-incubating/apache-sdap-nexusproto-1.0.0-incubating-src.tar.gz">
                 [source] apache-sdap-nexusproto-1.0.0-incubating-src.tar.gz
             </a>
-            <a href="https://www.apache.org/dyn/closer.lua/incubator/sdap/1.0.0-incubating/apache-sdap-nexusproto-1.0.0-incubating-src.tar.gz.asc">
+            <a href="https://downloads.apache.org/incubator/sdap/1.0.0-incubating/apache-sdap-nexusproto-1.0.0-incubating-src.tar.gz.asc">
                 [signature] apache-sdap-nexusproto-1.0.0-incubating-src.tar.gz
             </a>
-            <a href="https://www.apache.org/dyn/closer.lua/incubator/sdap/1.0.0-incubating/apache-sdap-nexusproto-1.0.0-incubating-src.tar.gz.sha512">
+            <a href="https://downloads.apache.org/incubator/sdap/1.0.0-incubating/apache-sdap-nexusproto-1.0.0-incubating-src.tar.gz.sha512">
                 [checksum] apache-sdap-nexusproto-1.0.0-incubating-src.tar.gz
             </a>
         </td>
     </tr>
+    
     </tbody>
 </table>
+
+<h3>Release History</h3>
+<table class="version-table">
+    <thead>
+    <tr>
+        <th>Release Version</th>
+        <th>Release Date</th>
+        <th>Component</th>
+        <th>Source Distribution</th>
+    </tr>
+    </thead>
+    <tbody>
+    
+    
+    
+    
+    <tr>
+        
+        <td rowspan="2">1.1.0</td>
+        <td rowspan="2">2023-05-15</td>
+        
+        
+        <td>Nexus</td>
+        <td>
+            <a href="https://www.apache.org/dyn/closer.lua/incubator/sdap/-incubating/apache-sdap-nexus--incubating-src.tar.gz">
+                [source] apache-sdap-nexus--incubating-src.tar.gz
+            </a>
+            <a href="https://downloads.apache.org/incubator/sdap/-incubating/apache-sdap-nexus--incubating-src.tar.gz.asc">
+                [signature] apache-sdap-nexus--incubating-src.tar.gz
+            </a>
+            <a href="https://downloads.apache.org/incubator/sdap/-incubating/apache-sdap-nexus--incubating-src.tar.gz.sha512">
+                [checksum] apache-sdap-nexus--incubating-src.tar.gz
+            </a>
+        </td>
+    </tr>
+    
+    <tr>
+        
+        <td>Ingester</td>
+        <td>
+            <a href="https://www.apache.org/dyn/closer.lua/incubator/sdap/-incubating/apache-sdap-ingester--incubating-src.tar.gz">
+                [source] apache-sdap-ingester--incubating-src.tar.gz
+            </a>
+            <a href="https://downloads.apache.org/incubator/sdap/-incubating/apache-sdap-ingester--incubating-src.tar.gz.asc">
+                [signature] apache-sdap-ingester--incubating-src.tar.gz
+            </a>
+            <a href="https://downloads.apache.org/incubator/sdap/-incubating/apache-sdap-ingester--incubating-src.tar.gz.sha512">
+                [checksum] apache-sdap-ingester--incubating-src.tar.gz
+            </a>
+        </td>
+    </tr>
+    
+    
+    
+    
+    <tr>
+        
+        <td rowspan="3">1.0.0</td>
+        <td rowspan="3">2023-01-18</td>
+        
+        
+        <td>Nexus</td>
+        <td>
+            <a href="https://www.apache.org/dyn/closer.lua/incubator/sdap/-incubating/apache-sdap-nexus--incubating-src.tar.gz">
+                [source] apache-sdap-nexus--incubating-src.tar.gz
+            </a>
+            <a href="https://downloads.apache.org/incubator/sdap/-incubating/apache-sdap-nexus--incubating-src.tar.gz.asc">
+                [signature] apache-sdap-nexus--incubating-src.tar.gz
+            </a>
+            <a href="https://downloads.apache.org/incubator/sdap/-incubating/apache-sdap-nexus--incubating-src.tar.gz.sha512">
+                [checksum] apache-sdap-nexus--incubating-src.tar.gz
+            </a>
+        </td>
+    </tr>
+    
+    <tr>
+        
+        <td>Ingester</td>
+        <td>
+            <a href="https://www.apache.org/dyn/closer.lua/incubator/sdap/-incubating/apache-sdap-ingester--incubating-src.tar.gz">
+                [source] apache-sdap-ingester--incubating-src.tar.gz
+            </a>
+            <a href="https://downloads.apache.org/incubator/sdap/-incubating/apache-sdap-ingester--incubating-src.tar.gz.asc">
+                [signature] apache-sdap-ingester--incubating-src.tar.gz
+            </a>
+            <a href="https://downloads.apache.org/incubator/sdap/-incubating/apache-sdap-ingester--incubating-src.tar.gz.sha512">
+                [checksum] apache-sdap-ingester--incubating-src.tar.gz
+            </a>
+        </td>
+    </tr>
+    
+    <tr>
+        
+        <td>Nexus Protobuf</td>
+        <td>
+            <a href="https://www.apache.org/dyn/closer.lua/incubator/sdap/-incubating/apache-sdap-nexusproto--incubating-src.tar.gz">
+                [source] apache-sdap-nexusproto--incubating-src.tar.gz
+            </a>
+            <a href="https://downloads.apache.org/incubator/sdap/-incubating/apache-sdap-nexusproto--incubating-src.tar.gz.asc">
+                [signature] apache-sdap-nexusproto--incubating-src.tar.gz
+            </a>
+            <a href="https://downloads.apache.org/incubator/sdap/-incubating/apache-sdap-nexusproto--incubating-src.tar.gz.sha512">
+                [checksum] apache-sdap-nexusproto--incubating-src.tar.gz
+            </a>
+        </td>
+    </tr>
+    
+    
+    </tbody>
+</table>
+
+
 
 <h2>Instructions</h2>
 

--- a/source/_data/releases.yml
+++ b/source/_data/releases.yml
@@ -3,11 +3,11 @@ releases:
   - component: nexus
     displayName: Nexus
     release: 1.1.0
-    releaseDate: 2023-05-15
+    releaseDate: 2023-05-16
   - component: ingester
     displayName: Ingester
     release: 1.1.0
-    releaseDate: 2023-05-15
+    releaseDate: 2023-05-16
   - component: nexusproto
     displayName: Nexus Protobuf
     release: 1.0.0
@@ -18,7 +18,7 @@ releases:
 #    releaseDate: TBD
   history:
   - release: 1.1.0
-    releaseDate: 2023-05-15
+    releaseDate: 2023-05-16
     components:
     - component: nexus
       displayName: Nexus

--- a/source/_data/releases.yml
+++ b/source/_data/releases.yml
@@ -2,46 +2,37 @@ releases:
   latest:
   - component: nexus
     displayName: Nexus
-    componentVersion: 1.1.0
     release: 1.1.0
     releaseDate: TBD
   - component: ingester
     displayName: Ingester
-    componentVersion: 1.1.0
     release: 1.1.0
     releaseDate: TBD
   - component: nexusproto
     displayName: Nexus Protobuf
-    componentVersion: 1.0.0
     release: 1.0.0
     releaseDate: 2023-01-18
-  - component: insitu
-    displayName: In-Situ Data Services
-    componentVersion: 1.0.0
-    release: 1.1.0
-    releaseDate: TBD
+#  - component: insitu
+#    displayName: In-Situ Data Services
+#    release: 1.1.0
+#    releaseDate: TBD
   history:
   - release: 1.1.0
     releaseDate: TBD
     components:
     - component: nexus
       displayName: Nexus
-      componentVersion: 1.1.0
     - component: ingester
       displayName: Ingester
-      componentVersion: 1.1.0
-    - component: insitu
-      displayName: In-Situ Data Services
-      componentVersion: 1.0.0
+#    - component: insitu
+#      displayName: In-Situ Data Services
+#      componentVersion: 1.0.0
   - release: 1.0.0
     releaseDate: 2023-01-18
     components:
     - component: nexus
       displayName: Nexus
-      componentVersion: 1.0.0
     - component: ingester
       displayName: Ingester
-      componentVersion: 1.0.0
     - component: nexusproto
       displayName: Nexus Protobuf
-      componentVersion: 1.0.0

--- a/source/_data/releases.yml
+++ b/source/_data/releases.yml
@@ -1,0 +1,47 @@
+releases:
+  latest:
+  - component: nexus
+    displayName: Nexus
+    componentVersion: 1.1.0
+    release: 1.1.0
+    releaseDate: TBD
+  - component: ingester
+    displayName: Ingester
+    componentVersion: 1.1.0
+    release: 1.1.0
+    releaseDate: TBD
+  - component: nexusproto
+    displayName: Nexus Protobuf
+    componentVersion: 1.0.0
+    release: 1.0.0
+    releaseDate: 2023-01-18
+  - component: insitu
+    displayName: In-Situ Data Services
+    componentVersion: 1.0.0
+    release: 1.1.0
+    releaseDate: TBD
+  history:
+  - release: 1.1.0
+    releaseDate: TBD
+    components:
+    - component: nexus
+      displayName: Nexus
+      componentVersion: 1.1.0
+    - component: ingester
+      displayName: Ingester
+      componentVersion: 1.1.0
+    - component: insitu
+      displayName: In-Situ Data Services
+      componentVersion: 1.0.0
+  - release: 1.0.0
+    releaseDate: 2023-01-18
+    components:
+    - component: nexus
+      displayName: Nexus
+      componentVersion: 1.0.0
+    - component: ingester
+      displayName: Ingester
+      componentVersion: 1.0.0
+    - component: nexusproto
+      displayName: Nexus Protobuf
+      componentVersion: 1.0.0

--- a/source/_data/releases.yml
+++ b/source/_data/releases.yml
@@ -3,11 +3,11 @@ releases:
   - component: nexus
     displayName: Nexus
     release: 1.1.0
-    releaseDate: TBD
+    releaseDate: 2023-05-15
   - component: ingester
     displayName: Ingester
     release: 1.1.0
-    releaseDate: TBD
+    releaseDate: 2023-05-15
   - component: nexusproto
     displayName: Nexus Protobuf
     release: 1.0.0
@@ -18,15 +18,12 @@ releases:
 #    releaseDate: TBD
   history:
   - release: 1.1.0
-    releaseDate: TBD
+    releaseDate: 2023-05-15
     components:
     - component: nexus
       displayName: Nexus
     - component: ingester
       displayName: Ingester
-#    - component: insitu
-#      displayName: In-Situ Data Services
-#      componentVersion: 1.0.0
   - release: 1.0.0
     releaseDate: 2023-01-18
     components:

--- a/source/build.sh
+++ b/source/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+cp -r _site/* ../

--- a/source/downloads.html
+++ b/source/downloads.html
@@ -8,20 +8,83 @@
 <p>The table below contains links to download the Apache SDAP (incubating) module source distributions as well as their signature and checksum files from ASF mirrors.</p>
 
 <h2>SDAP</h2>
-
+<h3>Latest Components</h3>
 <table class="version-table">
     <thead>
     <tr>
-        <th>Date</th>
-        <th>Version</th>
-        <th>Module</th>
+        <th>Component</th>
+        <th>Component Version</th>
+        <th>Release Version</th>
+        <th>Release Date</th>
         <th>Source Distribution</th>
     </tr>
     </thead>
     <tbody>
-    {% include release.html date="2023-01-18" version="1.0.0" %}
+    {% assign latest = site.data.releases.releases.latest %}
+    {% for component in latest %}
+    <tr>
+        <td>{{ component.displayName }}</td>
+        <td>{{ component.componentVersion }}</td>
+        <td>{{ component.release }}</td>
+        <td>{{ component.releaseDate }}</td>
+        <td>
+            <a href="https://www.apache.org/dyn/closer.lua/incubator/sdap/{{ component.release }}-incubating/apache-sdap-{{ component.component }}-{{ component.release }}-incubating-src.tar.gz">
+                [source] apache-sdap-{{ component.component }}-{{ component.release }}-incubating-src.tar.gz
+            </a>
+            <a href="https://www.apache.org/dyn/closer.lua/incubator/sdap/{{ component.release }}-incubating/apache-sdap-{{ component.component }}-{{ component.release }}-incubating-src.tar.gz.asc">
+                [signature] apache-sdap-{{ component.component }}-{{ component.release }}-incubating-src.tar.gz
+            </a>
+            <a href="https://www.apache.org/dyn/closer.lua/incubator/sdap/{{ component.release }}-incubating/apache-sdap-{{ component.component }}-{{ component.release }}-incubating-src.tar.gz.sha512">
+                [checksum] apache-sdap-{{ component.component }}-{{ component.release }}-incubating-src.tar.gz
+            </a>
+        </td>
+    </tr>
+    {% endfor %}
     </tbody>
 </table>
+
+<h3>Release History</h3>
+<table class="version-table">
+    <thead>
+    <tr>
+        <th>Release Version</th>
+        <th>Release Date</th>
+        <th>Component</th>
+        <th>Component Version</th>
+        <th>Source Distribution</th>
+    </tr>
+    </thead>
+    <tbody>
+    {% assign history = site.data.releases.releases.history %}
+    {% for release in history %}
+    {% assign first = true %}
+    {% for component in release.components %}
+    <tr>
+        {% if first %}
+        <td rowspan="{{ release.components.size }}">{{ release.release }}</td>
+        <td rowspan="{{ release.components.size }}">{{ release.releaseDate }}</td>
+        {% assign first = false %}
+        {% endif %}
+        <td>{{ component.displayName }}</td>
+        <td>{{ component.componentVersion }}</td>
+        <td>
+            <a href="https://www.apache.org/dyn/closer.lua/incubator/sdap/{{ component.release }}-incubating/apache-sdap-{{ component.component }}-{{ component.release }}-incubating-src.tar.gz">
+                [source] apache-sdap-{{ component.component }}-{{ component.release }}-incubating-src.tar.gz
+            </a>
+            <a href="https://www.apache.org/dyn/closer.lua/incubator/sdap/{{ component.release }}-incubating/apache-sdap-{{ component.component }}-{{ component.release }}-incubating-src.tar.gz.asc">
+                [signature] apache-sdap-{{ component.component }}-{{ component.release }}-incubating-src.tar.gz
+            </a>
+            <a href="https://www.apache.org/dyn/closer.lua/incubator/sdap/{{ component.release }}-incubating/apache-sdap-{{ component.component }}-{{ component.release }}-incubating-src.tar.gz.sha512">
+                [checksum] apache-sdap-{{ component.component }}-{{ component.release }}-incubating-src.tar.gz
+            </a>
+        </td>
+    </tr>
+    {% endfor %}
+    {% endfor %}
+    </tbody>
+</table>
+
+
 
 <h2>Instructions</h2>
 

--- a/source/downloads.html
+++ b/source/downloads.html
@@ -13,7 +13,6 @@
     <thead>
     <tr>
         <th>Component</th>
-        <th>Component Version</th>
         <th>Release Version</th>
         <th>Release Date</th>
         <th>Source Distribution</th>
@@ -24,7 +23,6 @@
     {% for component in latest %}
     <tr>
         <td>{{ component.displayName }}</td>
-        <td>{{ component.componentVersion }}</td>
         <td>{{ component.release }}</td>
         <td>{{ component.releaseDate }}</td>
         <td>
@@ -50,7 +48,6 @@
         <th>Release Version</th>
         <th>Release Date</th>
         <th>Component</th>
-        <th>Component Version</th>
         <th>Source Distribution</th>
     </tr>
     </thead>
@@ -66,7 +63,6 @@
         {% assign first = false %}
         {% endif %}
         <td>{{ component.displayName }}</td>
-        <td>{{ component.componentVersion }}</td>
         <td>
             <a href="https://www.apache.org/dyn/closer.lua/incubator/sdap/{{ component.release }}-incubating/apache-sdap-{{ component.component }}-{{ component.release }}-incubating-src.tar.gz">
                 [source] apache-sdap-{{ component.component }}-{{ component.release }}-incubating-src.tar.gz

--- a/source/downloads.html
+++ b/source/downloads.html
@@ -29,10 +29,10 @@
             <a href="https://www.apache.org/dyn/closer.lua/incubator/sdap/{{ component.release }}-incubating/apache-sdap-{{ component.component }}-{{ component.release }}-incubating-src.tar.gz">
                 [source] apache-sdap-{{ component.component }}-{{ component.release }}-incubating-src.tar.gz
             </a>
-            <a href="https://www.apache.org/dyn/closer.lua/incubator/sdap/{{ component.release }}-incubating/apache-sdap-{{ component.component }}-{{ component.release }}-incubating-src.tar.gz.asc">
+            <a href="https://downloads.apache.org/incubator/sdap/{{ component.release }}-incubating/apache-sdap-{{ component.component }}-{{ component.release }}-incubating-src.tar.gz.asc">
                 [signature] apache-sdap-{{ component.component }}-{{ component.release }}-incubating-src.tar.gz
             </a>
-            <a href="https://www.apache.org/dyn/closer.lua/incubator/sdap/{{ component.release }}-incubating/apache-sdap-{{ component.component }}-{{ component.release }}-incubating-src.tar.gz.sha512">
+            <a href="https://downloads.apache.org/incubator/sdap/{{ component.release }}-incubating/apache-sdap-{{ component.component }}-{{ component.release }}-incubating-src.tar.gz.sha512">
                 [checksum] apache-sdap-{{ component.component }}-{{ component.release }}-incubating-src.tar.gz
             </a>
         </td>
@@ -67,10 +67,10 @@
             <a href="https://www.apache.org/dyn/closer.lua/incubator/sdap/{{ component.release }}-incubating/apache-sdap-{{ component.component }}-{{ component.release }}-incubating-src.tar.gz">
                 [source] apache-sdap-{{ component.component }}-{{ component.release }}-incubating-src.tar.gz
             </a>
-            <a href="https://www.apache.org/dyn/closer.lua/incubator/sdap/{{ component.release }}-incubating/apache-sdap-{{ component.component }}-{{ component.release }}-incubating-src.tar.gz.asc">
+            <a href="https://downloads.apache.org/incubator/sdap/{{ component.release }}-incubating/apache-sdap-{{ component.component }}-{{ component.release }}-incubating-src.tar.gz.asc">
                 [signature] apache-sdap-{{ component.component }}-{{ component.release }}-incubating-src.tar.gz
             </a>
-            <a href="https://www.apache.org/dyn/closer.lua/incubator/sdap/{{ component.release }}-incubating/apache-sdap-{{ component.component }}-{{ component.release }}-incubating-src.tar.gz.sha512">
+            <a href="https://downloads.apache.org/incubator/sdap/{{ component.release }}-incubating/apache-sdap-{{ component.component }}-{{ component.release }}-incubating-src.tar.gz.sha512">
                 [checksum] apache-sdap-{{ component.component }}-{{ component.release }}-incubating-src.tar.gz
             </a>
         </td>


### PR DESCRIPTION
~~Does NOT make these changes live yet~~

- Updates website downloads page
  - Added table for release history and a table for latest SDAP components
  - Fixed ASF compliance issue for signature and checksum links
- Built changes for SDAP 1.1.0 release on 2023-05-16 and staged changes to go live on PR merge